### PR TITLE
Fix(deps): Update shelljs to >=0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "bower": "^1.3.3",
     "gulp-util": "^2.2.14",
-    "shelljs": "^0.3.0"
+    "shelljs": ">=0.8.5"
   }
 }


### PR DESCRIPTION
Upgrades shelljs to version 0.8.5 or later to resolve two Dependabot alerts related to improper privilege management.

The alerts specifically mentioned vulnerabilities in shelljs versions < 0.8.5, where output from the synchronous version of shell.exec() might be visible to other users on the same system in certain environments.

Note: `package-lock.json` was not automatically updated by running `npm install` due to persistent environment issues (command timeouts). You may need to manually update the lock file after merging.